### PR TITLE
feat: self-healing CLI — model subcommand family + doctor --fix (v0.2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 build/
 dist/
 .venv/
+.venv-*/
 venv/
 .pytest_cache/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--auto-download` to skip the prompt for scripted use.
 - New `scripts/uninstall.sh` — idempotent end-to-end uninstaller with
   `--dry-run`, `--yes`, and `--keep-models` flags.
-- 31 new unit tests covering the model registry, download path (against a
-  local HTTP server), and CLI dispatch — total now 45.
+- **`localcaption doctor --fix`** — self-heals a broken or missing install
+  end to end: installs missing system tools (`ffmpeg`/`cmake`/`git`) via
+  `brew`/`apt`, clones + builds whisper.cpp at the canonical XDG location,
+  downloads the requested model, then re-runs the diagnostics for
+  verification. Idempotent (no-ops when already installed).
+- New internal `localcaption.installer` module wrapping the install
+  steps in pure Python (`subprocess`-based, no bash dependency) so the
+  same logic runs from `doctor --fix`, the `install.sh` bootstrap, and
+  any future entry point.
+- New `InstallError` exception type for typed install-step failures.
+- Unit tests: full coverage of `installer` (detection, subprocess
+  wrapper, brew/apt selection, clone+build sequencing) and four new
+  `doctor --fix` cases (read-only-by-default invariant, happy path,
+  abort on failure, `--fix` advertised in `--help`). 68 tests total.
 
 ### Changed
 - `doctor` now prints **actionable, copy-pasteable fix hints** when checks
-  fail, including the new `localcaption model download <name>` recipe.
+  fail, including the new `localcaption model download <name>` recipe and
+  the one-shot `localcaption doctor --fix` command.
+- `doctor` also checks for `cmake` (needed to build whisper.cpp).
+- `scripts/install.sh` slimmed from 134 → 91 lines: it now only handles
+  the bootstrap (Python + `pipx` + `pipx install localcaption`) and then
+  delegates the heavy lifting (whisper.cpp + model + system deps) to
+  `localcaption doctor --fix`. Single source of truth.
 - README has a new "Managing models" section with a model-picker table.
 - The new `model` subcommand supersedes [#1] (switching the install default
   to `small.en`) — users now pick whatever model they want with one command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`localcaption model` subcommand family** for first-class whisper model
+  management. No more shelling into `download-ggml-model.sh`. Subcommands:
+  - `localcaption model list` — show every supported model with size +
+    install status (works even before whisper.cpp is installed).
+  - `localcaption model info <name>` — show metadata for one model.
+  - `localcaption model download <name>` — native Python downloader with
+    progress bar, atomic writes (`.part` → rename), Ctrl-C safety, and
+    truncation detection.
+  - `localcaption model rm <name>` — remove an installed model with a
+    confirmation prompt (`-y` to skip).
+- **Auto-download prompt for the transcribe path.** Running
+  `localcaption --model small.en <url>` when `small.en` isn't installed now
+  asks whether to download it, instead of failing with a path. Pass
+  `--auto-download` to skip the prompt for scripted use.
+- New `scripts/uninstall.sh` — idempotent end-to-end uninstaller with
+  `--dry-run`, `--yes`, and `--keep-models` flags.
+- 31 new unit tests covering the model registry, download path (against a
+  local HTTP server), and CLI dispatch — total now 45.
+
+### Changed
+- `doctor` now prints **actionable, copy-pasteable fix hints** when checks
+  fail, including the new `localcaption model download <name>` recipe.
+- README has a new "Managing models" section with a model-picker table.
+- The new `model` subcommand supersedes [#1] (switching the install default
+  to `small.en`) — users now pick whatever model they want with one command.
+
+### Fixed
+- CI no longer prints the "Node.js 20 actions deprecated" warning on every
+  run; opted in early to GitHub's Node 24 runtime via
+  `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.
+
+## [0.1.1] - 2026-04-21
+
+### Added
 - `scripts/install.sh` — one-line end-user installer that uses `pipx` for an
   isolated install and bootstraps `whisper.cpp` + a default model into
   `~/.local/share/localcaption/whisper.cpp` (XDG-compliant). After install,
@@ -22,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `localcaption` invoked with no arguments now prints top-level help and
   exits with code 2 (was: argparse error). Existing `localcaption <url>`
   usage is unchanged.
+
+[#1]: https://github.com/jatinkrmalik/localcaption/issues/1
 
 ## [0.1.0] - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,23 @@ pipx install localcaption
 ```
 
 The first time you run `localcaption <url>` it will tell you it can't find
-`whisper.cpp`. To set it up (clone + build + download the default model),
-use **either** of:
+`whisper.cpp`. The fastest way to set it up is to let `localcaption` do it
+itself — clone, build, and download the default model in one shot:
 
 ```bash
-# Option A — let our installer do it (XDG-compliant, ~2 min on M-series Mac):
+localcaption doctor --fix          # ~2 min on an M-series Mac
+```
+
+`doctor --fix` is idempotent and end-to-end: it installs missing system
+tools (`ffmpeg`/`cmake` via `brew`/`apt`), clones + builds whisper.cpp at
+the canonical XDG location, downloads the default model, and re-runs the
+diagnostics to confirm everything works. Pick a different model with
+`--model small.en`.
+
+Prefer to do it yourself? Two equivalent options:
+
+```bash
+# Option A — bootstrap script (also installs pipx + the localcaption package):
 curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/localcaption/main/scripts/install.sh | bash
 
 # Option B — DIY, anywhere you like:
@@ -65,17 +77,15 @@ bash models/download-ggml-model.sh base.en
 export LOCALCAPTION_WHISPER_DIR=/path/to/whisper.cpp   # add to your shell rc
 ```
 
-> 💡 **Already trust the install script?** Just run it directly — it'll do
-> `pipx install localcaption` for you, plus prereqs (`pipx`, `cmake` via
-> `brew`/`apt`) and the whisper.cpp bootstrap, all in one command:
-> `curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/localcaption/main/scripts/install.sh | bash`
->
+> 💡 The `install.sh` bootstrap is just `pipx install localcaption` followed
+> by `localcaption doctor --fix` — same logic, single source of truth.
 > Override the default model with `WHISPER_MODEL=small.en bash install.sh`.
 
 After install, verify everything is wired up:
 
 ```bash
-localcaption doctor
+localcaption doctor                # read-only diagnostic
+localcaption doctor --fix          # diagnostic + auto-repair anything missing
 ```
 
 ### Uninstall
@@ -98,11 +108,12 @@ models cache for next time).
 Sample output:
 
 ```
-localcaption 0.1.0
+localcaption 0.2.0
 
 System tools:
   ✅ python  (3.12.3)
   ✅ ffmpeg  (/opt/homebrew/bin/ffmpeg)
+  ✅ cmake   (/opt/homebrew/bin/cmake)
   ✅ git     (/opt/homebrew/bin/git)
 
 Python dependencies:
@@ -115,6 +126,15 @@ whisper.cpp:
   ✅ models present  (ggml-base.en.bin)
 
 All checks passed. You're good to go: localcaption <url>
+```
+
+If anything is missing, re-run with `--fix` and `localcaption` will install
+the missing system deps (via `brew`/`apt`), clone+build whisper.cpp, and
+download the default model — then re-verify:
+
+```bash
+localcaption doctor --fix                      # repair everything
+localcaption doctor --fix --model small.en     # …with a specific model
 ```
 
 ### Dev install (contributors)
@@ -164,7 +184,8 @@ You can also invoke it as a module: `python -m localcaption <url>`.
 | Subcommand | What it does |
 |---|---|
 | _(default)_ `localcaption <url>` | Transcribe a single URL. |
-| `localcaption doctor` | Diagnose your install: prereqs, whisper.cpp, available models. Useful before filing a bug. |
+| `localcaption doctor` | Read-only diagnostic: prereqs, whisper.cpp, available models. Useful before filing a bug. |
+| `localcaption doctor --fix` | Self-heal: install missing system deps, clone+build whisper.cpp, download the default model, then re-verify. Idempotent. |
 | `localcaption model list` | List every supported whisper model with size + install status. |
 | `localcaption model info <name>` | Show metadata about a single model. |
 | `localcaption model download <name>` | Download a model with progress bar + atomic writes. |

--- a/README.md
+++ b/README.md
@@ -165,6 +165,52 @@ You can also invoke it as a module: `python -m localcaption <url>`.
 |---|---|
 | _(default)_ `localcaption <url>` | Transcribe a single URL. |
 | `localcaption doctor` | Diagnose your install: prereqs, whisper.cpp, available models. Useful before filing a bug. |
+| `localcaption model list` | List every supported whisper model with size + install status. |
+| `localcaption model info <name>` | Show metadata about a single model. |
+| `localcaption model download <name>` | Download a model with progress bar + atomic writes. |
+| `localcaption model rm <name>` | Remove an installed model to free disk space. |
+
+### Managing models
+
+`localcaption` ships with a default `base.en` model (~142 MB). For better
+quality or non-English audio, switch models with `--model <name>`. If the
+model isn't already installed, you'll be prompted to download it:
+
+```bash
+$ localcaption --model small.en "https://www.youtube.com/watch?v=..."
+
+Model 'small.en' is not installed (~466 MB).
+  Download it now? [Y/n] y
+  small.en       [████████████████████░░░░░░░░░░░░░░░░] 290.0/466.0 MB · 18.4 MB/s · ETA 9s
+```
+
+Or download/manage models explicitly:
+
+```bash
+localcaption model list                  # see what's available
+localcaption model info small.en         # check size before committing
+localcaption model download small.en     # ~466 MB, ~25 sec on a fast connection
+localcaption model rm large-v3           # free 3 GB after experimenting
+```
+
+For scripted/CI use, pass `--auto-download` to skip the prompt:
+
+```bash
+localcaption --model small.en --auto-download "https://www.youtube.com/..."
+```
+
+**Quick model picker:**
+
+| Model | Size | Best for |
+|---|---|---|
+| `tiny.en` | 75 MB | Quick drafts, English only, low-resource environments |
+| `base.en` | 142 MB | Current install default, fast & decent |
+| `small.en` | 466 MB | **Recommended for English** — great accuracy/speed balance |
+| `medium.en` | 1.5 GB | High accuracy English, ~3× slower than `small.en` |
+| `large-v3` | 3.0 GB | Best accuracy, multilingual, slow |
+| `large-v3-turbo` | 1.6 GB | Near-large quality at ~half the size — great compromise |
+
+Models without the `.en` suffix are multilingual (required for non-English audio).
 
 ### Python API
 
@@ -272,12 +318,13 @@ criteria, and discussion):
 
 | # | Item | Labels |
 |---|---|---|
-| [#1](https://github.com/jatinkrmalik/localcaption/issues/1) | Switch default model from `base.en` to `small.en` | `good first issue` |
+| [#7](https://github.com/jatinkrmalik/localcaption/issues/7) | `localcaption model {list,download,rm,info}` subcommand | _shipped in v0.2.0_ ✅ |
 | [#2](https://github.com/jatinkrmalik/localcaption/issues/2) | Batch mode (`--batch urls.txt`) | `enhancement` |
 | [#3](https://github.com/jatinkrmalik/localcaption/issues/3) | Local auto-summary via Ollama (`--summary`) | `enhancement` |
 | [#4](https://github.com/jatinkrmalik/localcaption/issues/4) | Speaker diarization with pyannote.audio (`--diarize`) | `stretch`, `help wanted` |
 | [#5](https://github.com/jatinkrmalik/localcaption/issues/5) | YouTube chapters & grep-able search index | `enhancement` |
 | [#6](https://github.com/jatinkrmalik/localcaption/issues/6) | Pluggable transcription backends (faster-whisper / MLX) | `help wanted` |
+| ~~[#1](https://github.com/jatinkrmalik/localcaption/issues/1)~~ | ~~Switch default model from `base.en` to `small.en`~~ | _superseded by #7_ |
 
 **Have an idea?** Open a
 [feature request](https://github.com/jatinkrmalik/localcaption/issues/new/choose) —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "localcaption"
-version = "0.1.0"
+version = "0.2.0"
 description = "Fully-local YouTube → transcript pipeline using yt-dlp, ffmpeg, and whisper.cpp. No API keys."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # localcaption — end-user installer.
 #
-# Installs the `localcaption` command system-wide (via pipx) and bootstraps
-# everything it needs (whisper.cpp + a default model) so you can immediately
-# run `localcaption <youtube-url>` from any directory.
+# Bootstraps the `localcaption` CLI (via pipx) and then delegates the
+# heavy lifting (whisper.cpp clone+build, default model download, missing
+# system tools) to `localcaption doctor --fix` so we have ONE source of
+# truth for "what does a working install look like".
 #
 # Re-runnable: skips steps that are already done.
 #
@@ -14,9 +15,9 @@
 #   ./scripts/install.sh
 #
 # Env vars:
-#   WHISPER_MODEL   default: base.en   (tiny.en | base.en | small.en | medium.en | large-v3)
-#   LOCALCAPTION_PACKAGE_SPEC   default: localcaption  (override e.g. with a local path or git URL)
-#   PREFIX_DATA     default: $XDG_DATA_HOME or $HOME/.local/share
+#   WHISPER_MODEL              default: base.en
+#   LOCALCAPTION_PACKAGE_SPEC  default: localcaption  (override with a local path or git URL)
+#   PREFIX_DATA                default: $XDG_DATA_HOME or $HOME/.local/share
 
 set -euo pipefail
 
@@ -29,31 +30,17 @@ log()  { printf "\033[1;34m[install]\033[0m %s\n" "$*"; }
 warn() { printf "\033[1;33m[warn   ]\033[0m %s\n" "$*"; }
 die()  { printf "\033[1;31m[error  ]\033[0m %s\n" "$*" >&2; exit 1; }
 
-need_cmd() { command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1 — please install it first."; }
-
 # --- 0. Sanity ------------------------------------------------------------
 case "$(uname -s)" in
   Darwin|Linux) ;;
   *) die "Unsupported OS: $(uname -s). localcaption is tested on macOS and Linux." ;;
 esac
 
-# --- 1. System tools ------------------------------------------------------
-log "Checking system tools…"
-need_cmd python3
-need_cmd git
-need_cmd ffmpeg
-
-if ! command -v cmake >/dev/null 2>&1; then
-  if command -v brew >/dev/null 2>&1; then
-    log "cmake not found, installing via brew"
-    brew install cmake
-  elif command -v apt-get >/dev/null 2>&1; then
-    log "cmake not found, installing via apt"
-    sudo apt-get update -y && sudo apt-get install -y cmake
-  else
-    die "cmake not found and no brew/apt to install it. Please install cmake manually."
-  fi
-fi
+# --- 1. Prereq for *bootstrapping* localcaption itself --------------------
+# We only need python3 here. ffmpeg / cmake / git get installed (if missing)
+# by `localcaption doctor --fix` later — keeps install logic in one place.
+command -v python3 >/dev/null 2>&1 \
+  || die "python3 not found. Install Python 3.10+ first, then re-run."
 
 # --- 2. pipx --------------------------------------------------------------
 if ! command -v pipx >/dev/null 2>&1; then
@@ -77,55 +64,31 @@ else
   pipx install "${PKG_SPEC}"
 fi
 
-# --- 4. whisper.cpp clone + build (into XDG data dir) ---------------------
+# --- 4. Hand off to `localcaption doctor --fix` ---------------------------
+# This is the single source of truth for "make this install work":
+#   • installs missing system tools (ffmpeg, cmake, git) via brew/apt
+#   • clones + builds whisper.cpp at WHISPER_DIR
+#   • downloads the requested model
 mkdir -p "${DATA_DIR}"
-if [[ ! -d "${WHISPER_DIR}" ]]; then
-  log "Cloning whisper.cpp into ${WHISPER_DIR}"
-  git clone --depth 1 https://github.com/ggerganov/whisper.cpp "${WHISPER_DIR}"
-fi
 
-BIN_PATH=""
-for cand in \
-  "${WHISPER_DIR}/build/bin/whisper-cli" \
-  "${WHISPER_DIR}/build/bin/main" \
-  "${WHISPER_DIR}/main"; do
-  [[ -x "${cand}" ]] && BIN_PATH="${cand}" && break
-done
-
-if [[ -z "${BIN_PATH}" ]]; then
-  log "Building whisper.cpp (this may take a minute)"
-  pushd "${WHISPER_DIR}" >/dev/null
-  if [[ -f CMakeLists.txt ]]; then
-    cmake -B build -DCMAKE_BUILD_TYPE=Release >/dev/null
-    cmake --build build -j --config Release
-  else
-    make -j
-  fi
-  popd >/dev/null
-fi
-
-# --- 5. Download model ----------------------------------------------------
-# Prefer `localcaption model download` (single source of truth, atomic writes,
-# progress bar, friendly errors). Fall back to whisper.cpp's bash script if
-# `localcaption` isn't on PATH yet (rare race; pipx may need a shell rehash).
-MODEL_FILE="${WHISPER_DIR}/models/ggml-${MODEL}.bin"
-if [[ -f "${MODEL_FILE}" ]]; then
-  log "Model already present: ${MODEL_FILE}"
-elif command -v localcaption >/dev/null 2>&1; then
-  log "Downloading whisper model: ${MODEL} (via 'localcaption model download')"
-  LOCALCAPTION_WHISPER_DIR="${WHISPER_DIR}" \
-    localcaption model download "${MODEL}"
+if ! command -v localcaption >/dev/null 2>&1; then
+  warn "'localcaption' not yet on PATH (pipx may need a shell rehash)."
+  warn "Skipping auto-fix. After opening a new shell, run:"
+  warn "    LOCALCAPTION_WHISPER_DIR=${WHISPER_DIR} localcaption doctor --fix --model ${MODEL}"
 else
-  log "Downloading whisper model: ${MODEL} (via whisper.cpp's bash script)"
-  bash "${WHISPER_DIR}/models/download-ggml-model.sh" "${MODEL}"
+  log "Running 'localcaption doctor --fix' to set up whisper.cpp + model"
+  LOCALCAPTION_WHISPER_DIR="${WHISPER_DIR}" \
+    localcaption doctor --fix --model "${MODEL}" \
+    || die "Auto-fix failed. Run 'localcaption doctor' to diagnose, then retry."
 fi
 
-# --- 6. Done --------------------------------------------------------------
+# --- 5. Done --------------------------------------------------------------
 echo ""
 log "Install complete!"
 echo ""
 echo "  Run:        localcaption <youtube-url>"
 echo "  Diagnose:   localcaption doctor"
+echo "  Auto-heal:  localcaption doctor --fix"
 echo "  whisper.cpp lives at:  ${WHISPER_DIR}"
 echo ""
 if ! command -v localcaption >/dev/null 2>&1; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,12 +105,19 @@ if [[ -z "${BIN_PATH}" ]]; then
 fi
 
 # --- 5. Download model ----------------------------------------------------
+# Prefer `localcaption model download` (single source of truth, atomic writes,
+# progress bar, friendly errors). Fall back to whisper.cpp's bash script if
+# `localcaption` isn't on PATH yet (rare race; pipx may need a shell rehash).
 MODEL_FILE="${WHISPER_DIR}/models/ggml-${MODEL}.bin"
-if [[ ! -f "${MODEL_FILE}" ]]; then
-  log "Downloading whisper model: ${MODEL}"
-  bash "${WHISPER_DIR}/models/download-ggml-model.sh" "${MODEL}"
-else
+if [[ -f "${MODEL_FILE}" ]]; then
   log "Model already present: ${MODEL_FILE}"
+elif command -v localcaption >/dev/null 2>&1; then
+  log "Downloading whisper model: ${MODEL} (via 'localcaption model download')"
+  LOCALCAPTION_WHISPER_DIR="${WHISPER_DIR}" \
+    localcaption model download "${MODEL}"
+else
+  log "Downloading whisper model: ${MODEL} (via whisper.cpp's bash script)"
+  bash "${WHISPER_DIR}/models/download-ggml-model.sh" "${MODEL}"
 fi
 
 # --- 6. Done --------------------------------------------------------------

--- a/src/localcaption/cli.py
+++ b/src/localcaption/cli.py
@@ -212,29 +212,39 @@ def _check(label: str, ok: bool, detail: str = "") -> bool:
     return ok
 
 
-def _cmd_doctor(argv: list[str]) -> int:
-    """Diagnose a localcaption install: prereqs, whisper.cpp, models."""
-    parser = argparse.ArgumentParser(
-        prog="localcaption doctor",
-        description="Diagnose a localcaption install: external tools, "
-                    "whisper.cpp build, available models.",
-    )
-    parser.add_argument(
-        "--whisper-dir", type=Path, default=None,
-        help="check this whisper.cpp directory (default: auto-detect)",
-    )
-    args = parser.parse_args(argv)
+def _run_doctor_diagnostics(whisper_dir: Path) -> tuple[bool, list[str], dict[str, bool]]:
+    """Run all diagnostic checks and print results.
 
-    print(f"localcaption {__version__}\n")
+    Returns ``(all_ok, fix_hints, gaps)`` where ``gaps`` is a flag-bag the
+    ``--fix`` path consumes to decide which install steps to run:
 
+        {
+            "ffmpeg":   bool,   # missing system tool
+            "cmake":    bool,
+            "git":      bool,
+            "whisper":  bool,   # whisper.cpp missing or unbuilt
+            "model":    bool,   # no ggml-*.bin model present
+        }
+    """
+    gaps = {"ffmpeg": False, "cmake": False, "git": False,
+            "whisper": False, "model": False}
+    fix_hints: list[str] = []
     all_ok = True
 
     print("System tools:")
     all_ok &= _check("python", True, sys.version.split()[0])
     ff = shutil.which("ffmpeg")
     all_ok &= _check("ffmpeg", ff is not None, ff or "missing — `brew install ffmpeg`")
+    if ff is None:
+        gaps["ffmpeg"] = True
+    cm = shutil.which("cmake")
+    all_ok &= _check("cmake", cm is not None, cm or "missing — needed to build whisper.cpp")
+    if cm is None:
+        gaps["cmake"] = True
     git = shutil.which("git")
     all_ok &= _check("git", git is not None, git or "missing")
+    if git is None:
+        gaps["git"] = True
 
     print("\nPython dependencies:")
     try:
@@ -245,9 +255,7 @@ def _cmd_doctor(argv: list[str]) -> int:
         all_ok &= _check("yt-dlp", False, "missing — `pip install yt-dlp`")
 
     print("\nwhisper.cpp:")
-    whisper_dir = args.whisper_dir or _default_whisper_dir()
     print(f"  searching: {whisper_dir}")
-    fix_hints: list[str] = []
 
     if whisper_dir.is_dir():
         _check("directory exists", True, str(whisper_dir))
@@ -257,10 +265,12 @@ def _cmd_doctor(argv: list[str]) -> int:
             all_ok &= _check("binary built", True, str(binary))
         except LocalCaptionError as exc:
             all_ok &= _check("binary built", False, str(exc).splitlines()[0])
+            gaps["whisper"] = True
             fix_hints.append(
                 "whisper.cpp directory exists but isn't built. To build it:\n"
                 f"    cd {whisper_dir}\n"
-                "    cmake -B build && cmake --build build -j --config Release"
+                "    cmake -B build && cmake --build build -j --config Release\n"
+                "    (or just run: localcaption doctor --fix)"
             )
 
         models_dir = paths.models_dir
@@ -270,32 +280,39 @@ def _cmd_doctor(argv: list[str]) -> int:
                 _check("models present", True, ", ".join(available))
             else:
                 all_ok &= _check("models present", False, f"no ggml-*.bin in {models_dir}")
+                gaps["model"] = True
                 fix_hints.append(
                     "No whisper models are installed. To list, pick, and download one:\n"
                     "    localcaption model list\n"
                     "    localcaption model download base.en   # ~142 MB; English-only\n"
-                    "    localcaption model download small.en  # ~466 MB; better quality"
+                    "    localcaption model download small.en  # ~466 MB; better quality\n"
+                    "    (or just run: localcaption doctor --fix)"
                 )
         else:
             all_ok &= _check("models directory", False, str(models_dir))
+            gaps["model"] = True
             fix_hints.append(
                 f"models/ subdirectory missing under {whisper_dir} — "
                 "your whisper.cpp clone may be incomplete; re-clone it."
             )
     else:
         all_ok &= _check("directory exists", False, str(whisper_dir))
+        gaps["whisper"] = True
+        gaps["model"] = True
         fix_hints.append(
             "whisper.cpp is not installed. Pick ONE of:\n\n"
-            "  Option A — let our installer do it for you:\n"
+            "  Option A — let localcaption install it for you:\n"
+            "    localcaption doctor --fix\n\n"
+            "  Option B — bootstrap from scratch (also installs localcaption):\n"
             "    curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/"
             "localcaption/main/scripts/install.sh | bash\n\n"
-            "  Option B — DIY, anywhere you like:\n"
+            "  Option C — DIY, anywhere you like:\n"
             "    git clone https://github.com/ggerganov/whisper.cpp \\\n"
             "        ~/.local/share/localcaption/whisper.cpp\n"
             "    cd ~/.local/share/localcaption/whisper.cpp\n"
             "    cmake -B build && cmake --build build -j --config Release\n"
             "    bash models/download-ggml-model.sh base.en\n\n"
-            "  Option C — point us at an existing whisper.cpp checkout:\n"
+            "  Option D — point us at an existing whisper.cpp checkout:\n"
             "    export LOCALCAPTION_WHISPER_DIR=/path/to/your/whisper.cpp\n"
             "    # add that line to your shell rc to make it stick"
         )
@@ -305,19 +322,110 @@ def _cmd_doctor(argv: list[str]) -> int:
         marker = "✓" if c.is_dir() else "·"
         print(f"  {marker} {c}")
 
-    if fix_hints:
-        print("\nHow to fix:\n")
-        for hint in fix_hints:
-            for line in hint.splitlines():
-                print(f"  {line}" if line else "")
-            print()
+    return all_ok, fix_hints, gaps
+
+
+def _apply_doctor_fix(whisper_dir: Path, gaps: dict[str, bool], model: str) -> bool:
+    """Try to repair the gaps found by the diagnostic sweep.
+
+    Returns ``True`` if every attempted fix succeeded, ``False`` otherwise.
+    Each step is best-effort: a single failure is reported and the remaining
+    steps are skipped (the user can re-run after addressing the root cause).
+    """
+    from . import installer, models  # local imports keep --help cheap
+
+    print("\nAttempting fixes:\n")
+
+    # 1. System dependencies first (whisper build needs cmake & git).
+    for dep in ("git", "cmake", "ffmpeg"):
+        if gaps.get(dep):
+            print(f"▸ Installing system dependency: {dep}")
+            try:
+                installer.install_system_dep(dep)
+            except LocalCaptionError as exc:
+                print(f"  ❌ Could not install {dep}: {exc}")
+                return False
+            print(f"  ✅ {dep} installed")
+
+    # 2. whisper.cpp clone + build.
+    if gaps.get("whisper"):
+        print(f"▸ Installing whisper.cpp into {whisper_dir}")
+        try:
+            binary = installer.ensure_whisper_cpp(whisper_dir)
+        except LocalCaptionError as exc:
+            print(f"  ❌ Could not install whisper.cpp: {exc}")
+            return False
+        print(f"  ✅ whisper.cpp ready ({binary})")
+
+    # 3. Default model download (uses the same registry as `model download`).
+    if gaps.get("model"):
+        print(f"▸ Downloading model: {model}")
+        try:
+            target = models.download_model(model, whisper_dir)
+        except LocalCaptionError as exc:
+            print(f"  ❌ Could not download model: {exc}")
+            return False
+        print(f"  ✅ model downloaded ({target})")
+
+    return True
+
+
+def _cmd_doctor(argv: list[str]) -> int:
+    """Diagnose a localcaption install. With ``--fix``, also try to repair it."""
+    parser = argparse.ArgumentParser(
+        prog="localcaption doctor",
+        description="Diagnose a localcaption install: external tools, "
+                    "whisper.cpp build, available models. "
+                    "Use --fix to attempt automatic repair.",
+    )
+    parser.add_argument(
+        "--whisper-dir", type=Path, default=None,
+        help="check this whisper.cpp directory (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--fix", action="store_true",
+        help="attempt to install missing dependencies (ffmpeg/cmake), "
+             "clone+build whisper.cpp, and download the default model",
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL,
+        help=f"model to download when fixing a missing-model gap "
+             f"(default: {DEFAULT_MODEL})",
+    )
+    args = parser.parse_args(argv)
+
+    print(f"localcaption {__version__}\n")
+    whisper_dir = args.whisper_dir or _default_whisper_dir()
+
+    all_ok, fix_hints, gaps = _run_doctor_diagnostics(whisper_dir)
 
     if all_ok:
-        print("All checks passed. You're good to go: localcaption <url>")
+        print("\nAll checks passed. You're good to go: localcaption <url>")
         return 0
-    else:
-        print("Some checks failed. See 'How to fix' above.")
+
+    if not args.fix:
+        if fix_hints:
+            print("\nHow to fix:\n")
+            for hint in fix_hints:
+                for line in hint.splitlines():
+                    print(f"  {line}" if line else "")
+                print()
+        print("Some checks failed. See 'How to fix' above, or re-run with --fix.")
         return 1
+
+    # --fix path: try to repair, then re-run diagnostics for verification.
+    if not _apply_doctor_fix(whisper_dir, gaps, args.model):
+        print("\nFix aborted. Address the error above and re-run.")
+        return 1
+
+    print("\n" + "─" * 60)
+    print("Re-running diagnostics to verify…\n")
+    all_ok_after, _, _ = _run_doctor_diagnostics(whisper_dir)
+    if all_ok_after:
+        print("\nAll checks passed. You're good to go: localcaption <url>")
+        return 0
+    print("\nSome checks still failing — see output above.")
+    return 1
 
 
 # --- top-level dispatcher -------------------------------------------------

--- a/src/localcaption/cli.py
+++ b/src/localcaption/cli.py
@@ -98,13 +98,83 @@ def _build_transcribe_parser() -> argparse.ArgumentParser:
         "--no-print", action="store_true",
         help="do not echo the transcript to stdout when finished",
     )
+    parser.add_argument(
+        "--auto-download", action="store_true",
+        help="if the requested model isn't installed, download it without asking",
+    )
     parser.add_argument("-V", "--version", action="version", version=f"%(prog)s {__version__}")
     return parser
+
+
+def _ensure_model_available(model: str, whisper_dir: Path, auto: bool) -> bool:
+    """If the requested model isn't installed, prompt and download it.
+
+    Returns True if the model is now available, False otherwise.
+    Errors are logged but never raised — caller decides what to do.
+    """
+    from . import models  # local import → keeps `localcaption --help` cheap
+
+    target = models.model_path(whisper_dir, model)
+    if target.is_file():
+        return True
+
+    # Unknown model? Don't even try to download — fail loud.
+    try:
+        spec = models.get_model(model)
+    except LocalCaptionError as exc:
+        log.error(str(exc))
+        return False
+
+    print(
+        f"\nModel '{spec.name}' is not installed "
+        f"(~{_format_size_mb(spec.approx_size_mb)})."
+    )
+
+    if auto:
+        proceed = True
+    elif not sys.stdin.isatty():
+        # Non-interactive (CI, piped stdin) without --auto-download → refuse.
+        log.error(
+            f"Cannot prompt to download {spec.name!r} (stdin is not a TTY).\n"
+            f"  Pass --auto-download, or run: localcaption model download {spec.name}"
+        )
+        return False
+    else:
+        try:
+            reply = input("  Download it now? [Y/n] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nCancelled.")
+            return False
+        proceed = reply in {"", "y", "yes"}
+
+    if not proceed:
+        print(
+            f"  Skipped. Run: localcaption model download {spec.name}\n"
+            "  Or use a different model with --model <name>."
+        )
+        return False
+
+    try:
+        models.download_model(spec.name, whisper_dir)
+    except LocalCaptionError as exc:
+        log.error(str(exc))
+        return False
+    except KeyboardInterrupt:
+        log.error("interrupted; partial download cleaned up.")
+        return False
+    return True
 
 
 def _cmd_transcribe(argv: list[str]) -> int:
     args = _build_transcribe_parser().parse_args(argv)
     whisper_dir = args.whisper_dir or _default_whisper_dir()
+
+    # Pre-flight: ensure the requested model is on disk before doing the (slow)
+    # download+ffmpeg dance. Cheap if already installed, helpful if not.
+    if whisper_dir.is_dir() and not _ensure_model_available(
+        args.model, whisper_dir, args.auto_download
+    ):
+        return 1
 
     try:
         result = transcribe_url(
@@ -201,8 +271,10 @@ def _cmd_doctor(argv: list[str]) -> int:
             else:
                 all_ok &= _check("models present", False, f"no ggml-*.bin in {models_dir}")
                 fix_hints.append(
-                    "No ggml-*.bin model files found. To download the default model:\n"
-                    f"    bash {models_dir}/download-ggml-model.sh base.en"
+                    "No whisper models are installed. To list, pick, and download one:\n"
+                    "    localcaption model list\n"
+                    "    localcaption model download base.en   # ~142 MB; English-only\n"
+                    "    localcaption model download small.en  # ~466 MB; better quality"
                 )
         else:
             all_ok &= _check("models directory", False, str(models_dir))
@@ -250,10 +322,207 @@ def _cmd_doctor(argv: list[str]) -> int:
 
 # --- top-level dispatcher -------------------------------------------------
 
+# ──────────────────────────────────────────────────────────────────────
+# `model` subcommand family
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _format_size_mb(mb: int) -> str:
+    if mb >= 1024:
+        return f"{mb / 1024:.1f} GB"
+    return f"{mb} MB"
+
+
+def _cmd_model(argv: list[str]) -> int:
+    """Dispatch `localcaption model {list,download,rm,info}`."""
+    if not argv or argv[0] in {"-h", "--help", "help"}:
+        print(
+            "usage: localcaption model <subcommand> [options]\n\n"
+            "subcommands:\n"
+            "  list                list every supported model + install status\n"
+            "  download <name>     download a model (e.g. small.en)\n"
+            "  rm <name>           remove an installed model\n"
+            "  info <name>         show details about one model\n"
+        )
+        return 0 if argv and argv[0] in {"-h", "--help", "help"} else 2
+
+    sub = argv[0]
+    rest = argv[1:]
+    if sub == "list":
+        return _cmd_model_list(rest)
+    if sub == "download":
+        return _cmd_model_download(rest)
+    if sub in {"rm", "remove", "delete"}:
+        return _cmd_model_rm(rest)
+    if sub == "info":
+        return _cmd_model_info(rest)
+
+    print(f"localcaption model: unknown subcommand: {sub}", file=sys.stderr)
+    print("Run `localcaption model --help` to see available subcommands.", file=sys.stderr)
+    return 2
+
+
+def _cmd_model_list(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="localcaption model list")
+    parser.add_argument("--whisper-dir", type=Path, default=None,
+                        help="override whisper.cpp location")
+    args = parser.parse_args(argv)
+
+    # Avoid an immediate crash when whisper.cpp isn't installed yet — we still
+    # want to be able to LIST models (so the user can decide what to download).
+    whisper_dir = args.whisper_dir or _default_whisper_dir()
+
+    # We don't import models at top of file to keep CLI startup lean
+    from . import models
+
+    table = models.list_status(whisper_dir)
+
+    print("Models available for download (from whisper.cpp upstream):\n")
+    print(f"  {'Name':<18}{'Size':>10}   Status")
+    print(f"  {'-' * 18:<18}{'-' * 10:>10}   {'-' * 11}")
+    for row in table:
+        size = _format_size_mb(row.spec.approx_size_mb)
+        status = "✅ installed" if row.is_installed else "not installed"
+        print(f"  {row.spec.name:<18}{size:>10}   {status}")
+
+    orphans = models.orphaned_installed_models(whisper_dir)
+    if orphans:
+        print("\nOther models found on disk (not in localcaption's registry):")
+        for name in orphans:
+            print(f"  {name}")
+        print("These work fine with `--model <name>`; they just aren't shown above.")
+
+    print(f"\nInstall location: {models.WhisperPaths(whisper_dir).models_dir}")
+    print("\nTips:")
+    print("  • Multilingual variants (no .en suffix) are required for non-English audio.")
+    print("  • small.en is a great default for English podcasts/lectures.")
+    print("  • To download:    localcaption model download small.en")
+    print("  • To remove:      localcaption model rm small.en")
+    return 0
+
+
+def _cmd_model_info(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="localcaption model info")
+    parser.add_argument("name", help="model name (e.g. small.en)")
+    parser.add_argument("--whisper-dir", type=Path, default=None,
+                        help="override whisper.cpp location")
+    args = parser.parse_args(argv)
+
+    from . import models
+    try:
+        spec = models.get_model(args.name)
+    except LocalCaptionError as exc:
+        print(f"localcaption: {exc}", file=sys.stderr)
+        return 2
+
+    whisper_dir = args.whisper_dir or _default_whisper_dir()
+    target = models.model_path(whisper_dir, spec.name)
+    installed = target.is_file()
+
+    print(f"Model:        {spec.name}")
+    print(f"Description:  {spec.description}")
+    print(f"Approx size:  {_format_size_mb(spec.approx_size_mb)}")
+    print(f"Language:     {'English-only' if spec.is_english_only else 'multilingual'}")
+    print(f"Source URL:   {spec.url}")
+    print(f"Local path:   {target}")
+    if installed:
+        actual_mb = max(1, target.stat().st_size // (1024 * 1024))
+        print(f"Installed:    yes ({actual_mb} MB on disk)")
+    else:
+        print("Installed:    no")
+        print(f"\nDownload with:  localcaption model download {spec.name}")
+    return 0
+
+
+def _cmd_model_download(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="localcaption model download")
+    parser.add_argument("name", help="model name (e.g. small.en)")
+    parser.add_argument("--whisper-dir", type=Path, default=None,
+                        help="override whisper.cpp location")
+    parser.add_argument("--force", action="store_true",
+                        help="re-download even if the model is already present")
+    args = parser.parse_args(argv)
+
+    from . import models
+
+    whisper_dir = args.whisper_dir or _default_whisper_dir()
+    if not whisper_dir.is_dir():
+        print(
+            f"localcaption: whisper.cpp not found at {whisper_dir}.\n"
+            "  Install it first: see `localcaption doctor`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        spec = models.get_model(args.name)
+    except LocalCaptionError as exc:
+        print(f"localcaption: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"▸ Downloading whisper model: {spec.name} (~{_format_size_mb(spec.approx_size_mb)})")
+    try:
+        path = models.download_model(spec.name, whisper_dir, force=args.force)
+    except LocalCaptionError as exc:
+        print(f"\nlocalcaption: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\nlocalcaption: interrupted; partial download cleaned up.", file=sys.stderr)
+        return 130
+
+    print(f"✅ Done. {path}")
+    print(f"   Use it with: localcaption --model {spec.name} <url>")
+    return 0
+
+
+def _cmd_model_rm(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="localcaption model rm")
+    parser.add_argument("name", help="model name (e.g. small.en)")
+    parser.add_argument("--whisper-dir", type=Path, default=None,
+                        help="override whisper.cpp location")
+    parser.add_argument("-y", "--yes", action="store_true",
+                        help="skip the confirmation prompt")
+    args = parser.parse_args(argv)
+
+    from . import models
+
+    whisper_dir = args.whisper_dir or _default_whisper_dir()
+    target = models.model_path(whisper_dir, args.name)
+    if not target.is_file():
+        print(
+            f"localcaption: model {args.name!r} is not installed at {target}\n"
+            "  Run `localcaption model list` to see installed models.",
+            file=sys.stderr,
+        )
+        return 1
+
+    size_mb = max(1, target.stat().st_size // (1024 * 1024))
+    print(f"About to remove: {target} ({_format_size_mb(size_mb)})")
+    if not args.yes:
+        try:
+            reply = input("Continue? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nCancelled.", file=sys.stderr)
+            return 130
+        if reply not in {"y", "yes"}:
+            print("Cancelled.")
+            return 0
+
+    try:
+        models.remove_model(args.name, whisper_dir)
+    except LocalCaptionError as exc:
+        print(f"localcaption: {exc}", file=sys.stderr)
+        return 1
+
+    print("✓ Removed.")
+    return 0
+
+
 def _print_top_level_help() -> None:
     print("""\
 usage: localcaption <url> [options]            transcribe a video (default)
        localcaption doctor                     diagnose your install
+       localcaption model <subcommand>         list / download / remove models
        localcaption --help                     show transcribe help
        localcaption --version                  print version
 
@@ -278,6 +547,8 @@ def main(argv: list[str] | None = None) -> int:
     # Explicit subcommands.
     if head == "doctor":
         return _cmd_doctor(argv[1:])
+    if head == "model":
+        return _cmd_model(argv[1:])
     if head == "transcribe":
         return _cmd_transcribe(argv[1:])
 

--- a/src/localcaption/errors.py
+++ b/src/localcaption/errors.py
@@ -25,3 +25,7 @@ class AudioConversionError(LocalCaptionError):
 
 class TranscriptionError(LocalCaptionError):
     """whisper.cpp failed to produce a transcript."""
+
+
+class InstallError(LocalCaptionError):
+    """An automated install step (system dep, whisper.cpp clone/build) failed."""

--- a/src/localcaption/installer.py
+++ b/src/localcaption/installer.py
@@ -1,0 +1,219 @@
+"""Self-healing installer for localcaption's external dependencies.
+
+This module exists so ``localcaption doctor --fix`` can put a broken or
+missing install back together without shelling out to ``install.sh``. The
+shell script remains the bootstrap for first-time users (it's the thing
+``curl | bash`` invokes), but the *logic* lives here so we have one place
+to test it from and one place to evolve it.
+
+Three concerns, three small entry points:
+
+* :func:`install_system_dep` — install ffmpeg/cmake via brew/apt.
+* :func:`ensure_whisper_cpp` — clone + build whisper.cpp at a chosen path.
+* :func:`detect_platform` / :func:`detect_package_manager` — used by both
+  callers and tests to decide what's even possible on this host.
+
+All failures raise :class:`~localcaption.errors.InstallError` with an
+actionable, copy-pasteable message — never a bare ``CalledProcessError``.
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Literal
+
+from . import _logging as log
+from .errors import InstallError
+from .whisper import WhisperPaths
+
+Platform = Literal["macos", "linux", "unsupported"]
+PackageManager = Literal["brew", "apt"]
+
+# System dependencies we know how to install. Map: dep name → package name
+# under each package manager. ``None`` means "package name matches dep name".
+_SYSTEM_DEP_PACKAGES: dict[str, dict[PackageManager, str]] = {
+    "ffmpeg": {"brew": "ffmpeg", "apt": "ffmpeg"},
+    "cmake": {"brew": "cmake", "apt": "cmake"},
+    "git": {"brew": "git", "apt": "git"},
+}
+
+WHISPER_CPP_REPO = "https://github.com/ggerganov/whisper.cpp"
+
+
+# --- Detection helpers ----------------------------------------------------
+
+
+def detect_platform() -> Platform:
+    """Return ``"macos"``, ``"linux"``, or ``"unsupported"``."""
+    system = platform.system()
+    if system == "Darwin":
+        return "macos"
+    if system == "Linux":
+        return "linux"
+    return "unsupported"
+
+
+def detect_package_manager() -> PackageManager | None:
+    """Return the first package manager we can drive on this host, if any.
+
+    macOS prefers Homebrew, Linux prefers apt. Everything else returns
+    ``None`` and the caller is expected to print a manual-install hint.
+    """
+    if shutil.which("brew"):
+        return "brew"
+    if shutil.which("apt-get"):
+        return "apt"
+    return None
+
+
+# --- Subprocess wrapper ---------------------------------------------------
+
+
+def _run(cmd: list[str], *, label: str, cwd: Path | None = None) -> None:
+    """Run *cmd*, streaming output to the user's terminal.
+
+    On non-zero exit raises :class:`InstallError` with an actionable message
+    that includes the failed command and the working directory. We
+    deliberately do **not** capture stdout/stderr — for long-running steps
+    like ``cmake --build`` the live progress is the UX.
+    """
+    pretty = " ".join(cmd)
+    log.info(f"{label}: {pretty}")
+    try:
+        subprocess.run(cmd, cwd=cwd, check=True)
+    except FileNotFoundError as exc:
+        raise InstallError(
+            f"{label} failed: command not found ({cmd[0]}). "
+            f"Install it first, then re-run."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        loc = f" (in {cwd})" if cwd else ""
+        raise InstallError(
+            f"{label} failed (exit {exc.returncode}){loc}:\n    {pretty}"
+        ) from exc
+
+
+# --- System deps ----------------------------------------------------------
+
+
+def install_system_dep(name: str) -> None:
+    """Install a system tool (``ffmpeg``, ``cmake``, ``git``) via the host's
+    package manager. No-op if the tool is already on ``PATH``.
+
+    Raises :class:`InstallError` if the dependency is unknown to us, the
+    platform is unsupported, or no package manager is available.
+    """
+    if shutil.which(name):
+        log.info(f"{name}: already installed")
+        return
+
+    if name not in _SYSTEM_DEP_PACKAGES:
+        raise InstallError(
+            f"Don't know how to install '{name}' automatically. "
+            f"Please install it manually and re-run."
+        )
+
+    pm = detect_package_manager()
+    if pm is None:
+        plat = detect_platform()
+        hint = (
+            "brew install ffmpeg cmake git" if plat == "macos"
+            else "sudo apt-get install -y ffmpeg cmake git"
+        )
+        raise InstallError(
+            f"No supported package manager found (need brew or apt-get) "
+            f"to install '{name}'.\n"
+            f"Install it manually:\n    {hint}"
+        )
+
+    pkg = _SYSTEM_DEP_PACKAGES[name][pm]
+    if pm == "brew":
+        _run(["brew", "install", pkg], label=f"install {name}")
+    else:  # apt
+        _run(["sudo", "apt-get", "update", "-y"], label="apt update")
+        _run(["sudo", "apt-get", "install", "-y", pkg], label=f"install {name}")
+
+
+# --- whisper.cpp ----------------------------------------------------------
+
+
+def ensure_whisper_cpp(whisper_dir: Path) -> Path:
+    """Make sure a built whisper.cpp checkout lives at *whisper_dir*.
+
+    Steps (each is idempotent — skipped if already done):
+
+    1. ``git clone --depth 1`` the repo if the directory is missing.
+    2. ``cmake -B build && cmake --build build`` if the binary isn't found.
+
+    Returns the path to the executable. Raises :class:`InstallError` on
+    any failure with a copy-pasteable message.
+    """
+    whisper_dir = whisper_dir.expanduser()
+    paths = WhisperPaths(whisper_dir)
+
+    # 1. Clone if missing.
+    if not whisper_dir.exists():
+        if not shutil.which("git"):
+            raise InstallError(
+                "git is required to clone whisper.cpp but isn't installed.\n"
+                "    macOS:  brew install git\n"
+                "    Linux:  sudo apt-get install -y git"
+            )
+        whisper_dir.parent.mkdir(parents=True, exist_ok=True)
+        _run(
+            ["git", "clone", "--depth", "1", WHISPER_CPP_REPO, str(whisper_dir)],
+            label="clone whisper.cpp",
+        )
+    elif not whisper_dir.is_dir():
+        raise InstallError(
+            f"{whisper_dir} exists but is not a directory. "
+            f"Move it aside and re-run."
+        )
+    else:
+        log.info(f"whisper.cpp: already cloned at {whisper_dir}")
+
+    # 2. Build if no binary present.
+    try:
+        binary = paths.find_binary()
+        log.info(f"whisper.cpp: already built at {binary}")
+        return binary
+    except LookupError:
+        pass  # not raised by find_binary — guard kept for future-proofing
+    except Exception:
+        # find_binary raises DependencyError when no binary is found; we
+        # treat any "not found" as "needs building" and let the build step
+        # surface a real error if something deeper is wrong.
+        pass
+
+    if not shutil.which("cmake"):
+        raise InstallError(
+            "cmake is required to build whisper.cpp but isn't installed.\n"
+            "    macOS:  brew install cmake\n"
+            "    Linux:  sudo apt-get install -y cmake"
+        )
+
+    cmakelists = whisper_dir / "CMakeLists.txt"
+    if cmakelists.is_file():
+        _run(
+            ["cmake", "-B", "build", "-DCMAKE_BUILD_TYPE=Release"],
+            label="cmake configure",
+            cwd=whisper_dir,
+        )
+        _run(
+            ["cmake", "--build", "build", "-j", "--config", "Release"],
+            label="cmake build",
+            cwd=whisper_dir,
+        )
+    else:
+        # Older whisper.cpp checkouts only ship a Makefile.
+        if not shutil.which("make"):
+            raise InstallError(
+                "Neither CMakeLists.txt nor make found for whisper.cpp build."
+            )
+        _run(["make", "-j"], label="make whisper.cpp", cwd=whisper_dir)
+
+    # Re-resolve to confirm a binary now exists.
+    return paths.find_binary()

--- a/src/localcaption/models.py
+++ b/src/localcaption/models.py
@@ -1,0 +1,347 @@
+"""Whisper.cpp model registry, download, listing, and removal.
+
+This module is the single source of truth for which whisper.cpp models
+``localcaption`` knows about. It deliberately mirrors the upstream
+``download-ggml-model.sh`` from ggerganov/whisper.cpp so any name that
+works with the bash script also works here.
+
+The download is implemented with the standard library only (urllib +
+hashlib + a small progress callback) so we don't add third-party
+dependencies for what is essentially `curl + sha256sum`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import DependencyError, LocalCaptionError
+from .whisper import WhisperPaths
+
+# ──────────────────────────────────────────────────────────────────────
+# Registry
+# ──────────────────────────────────────────────────────────────────────
+
+# Sources are kept in lock-step with whisper.cpp's download-ggml-model.sh:
+#   https://github.com/ggerganov/whisper.cpp/blob/master/models/download-ggml-model.sh
+HF_BASE_URL = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main"
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Static metadata about a single whisper.cpp model."""
+
+    name: str
+    approx_size_mb: int   # rounded, for human display only
+    description: str
+
+    @property
+    def filename(self) -> str:
+        return f"ggml-{self.name}.bin"
+
+    @property
+    def url(self) -> str:
+        return f"{HF_BASE_URL}/{self.filename}"
+
+    @property
+    def is_english_only(self) -> bool:
+        # whisper.cpp uses the '.en' suffix on English-only checkpoints.
+        return ".en" in self.name
+
+
+# Curated subset that 99% of users will actually want. The full upstream
+# script lists ~30 quantised variants; we expose the high-signal ones and
+# let advanced users add others via `model add` (out-of-scope for v0.2.0).
+_REGISTRY: tuple[ModelSpec, ...] = (
+    ModelSpec("tiny.en",         75,    "smallest English-only — fastest, lowest quality"),
+    ModelSpec("tiny",            75,    "smallest multilingual — fastest, lowest quality"),
+    ModelSpec("base.en",        142,    "small English-only — current install default"),
+    ModelSpec("base",           142,    "small multilingual"),
+    ModelSpec("small.en",       466,    "good general-purpose English (recommended)"),
+    ModelSpec("small",          466,    "good general-purpose multilingual"),
+    ModelSpec("medium.en",     1500,    "high-accuracy English — slower"),
+    ModelSpec("medium",        1500,    "high-accuracy multilingual — slower"),
+    ModelSpec("large-v3",      3100,    "best accuracy — large multilingual model"),
+    ModelSpec("large-v3-turbo", 1620,   "near-large accuracy at ~half the size"),
+)
+
+
+def known_models() -> tuple[ModelSpec, ...]:
+    """All models the registry knows about, ordered smallest-to-largest."""
+    return tuple(sorted(_REGISTRY, key=lambda m: (m.approx_size_mb, m.name)))
+
+
+def get_model(name: str) -> ModelSpec:
+    """Look up a model by name. Raises ``LocalCaptionError`` if unknown."""
+    for spec in _REGISTRY:
+        if spec.name == name:
+            return spec
+    valid = ", ".join(m.name for m in known_models())
+    raise LocalCaptionError(
+        f"Unknown model: {name!r}\n"
+        f"Run `localcaption model list` to see all supported models.\n"
+        f"Valid names: {valid}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Disk introspection
+# ──────────────────────────────────────────────────────────────────────
+
+
+def installed_model_files(whisper_dir: Path) -> dict[str, Path]:
+    """Map of installed model name → on-disk path under *whisper_dir*."""
+    models_dir = WhisperPaths(whisper_dir).models_dir
+    if not models_dir.is_dir():
+        return {}
+    found: dict[str, Path] = {}
+    for path in sorted(models_dir.glob("ggml-*.bin")):
+        # ggml-base.en.bin -> base.en
+        name = path.stem.removeprefix("ggml-")
+        found[name] = path
+    return found
+
+
+def model_path(whisper_dir: Path, name: str) -> Path:
+    """Where a given model would live on disk (whether installed or not)."""
+    return WhisperPaths(whisper_dir).model_file(name)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Download
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _human_bytes(num: float) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if num < 1024:
+            return f"{num:.1f} {unit}"
+        num /= 1024
+    return f"{num:.1f} TB"
+
+
+def _format_eta(seconds: float) -> str:
+    if seconds < 0 or seconds > 86_400:
+        return "?"
+    if seconds < 60:
+        return f"{int(seconds):d}s"
+    if seconds < 3600:
+        return f"{int(seconds // 60):d}m{int(seconds % 60):02d}s"
+    return f"{int(seconds // 3600):d}h{int((seconds % 3600) // 60):02d}m"
+
+
+class _ProgressBar:
+    """Tiny self-contained progress bar so we don't add tqdm.
+
+    Renders nothing if stderr is not a TTY (so logs stay clean in CI).
+    """
+
+    BAR_WIDTH = 36
+
+    def __init__(self, total: int, label: str):
+        self.total = total
+        self.label = label
+        self.start = time.monotonic()
+        self.last_render = 0.0
+        self.tty = sys.stderr.isatty()
+
+    def update(self, downloaded: int) -> None:
+        now = time.monotonic()
+        # throttle: redraw at most every 0.1 s, plus always on completion
+        if not self.tty:
+            return
+        if downloaded < self.total and (now - self.last_render) < 0.1:
+            return
+        self.last_render = now
+        elapsed = max(now - self.start, 0.001)
+        speed = downloaded / elapsed
+        if self.total > 0:
+            ratio = min(downloaded / self.total, 1.0)
+            filled = int(self.BAR_WIDTH * ratio)
+            bar = "█" * filled + "░" * (self.BAR_WIDTH - filled)
+            remaining = (self.total - downloaded) / speed if speed > 0 else 0
+            line = (
+                f"\r  {self.label} [{bar}] "
+                f"{_human_bytes(downloaded)}/{_human_bytes(self.total)} · "
+                f"{_human_bytes(speed)}/s · ETA {_format_eta(remaining)}"
+            )
+        else:
+            line = f"\r  {self.label} {_human_bytes(downloaded)} @ {_human_bytes(speed)}/s"
+        # pad with spaces to clear any leftover characters from a previous wider line
+        sys.stderr.write(line + "   ")
+        sys.stderr.flush()
+
+    def finish(self) -> None:
+        if self.tty:
+            sys.stderr.write("\n")
+            sys.stderr.flush()
+
+
+def _open_with_redirects(url: str, timeout: float = 30.0):
+    """urlopen with a friendly user-agent (HuggingFace is more reliable with one)."""
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "localcaption-model-downloader/0.2"},
+    )
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def download_model(
+    name: str,
+    whisper_dir: Path,
+    *,
+    force: bool = False,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> Path:
+    """Download model *name* into *whisper_dir*'s ``models/`` directory.
+
+    Args:
+        name:        Model name (e.g. ``"small.en"``); must be in the registry.
+        whisper_dir: Root of the whisper.cpp checkout.
+        force:       Re-download even if the file already exists.
+        on_progress: Optional ``(downloaded_bytes, total_bytes) -> None`` callback,
+                     useful for tests; defaults to a TTY progress bar.
+
+    Returns:
+        The absolute path to the downloaded model file.
+    """
+    spec = get_model(name)  # raises if unknown — fail fast
+    target = model_path(whisper_dir, name)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if target.is_file() and not force:
+        return target
+
+    # Atomic-ish download: write to .part then rename on success.
+    # Avoids leaving a half-downloaded file at the canonical path on Ctrl-C.
+    tmp = target.with_suffix(target.suffix + ".part")
+    if tmp.exists():
+        tmp.unlink()
+
+    print(f"  Source: {spec.url}")
+    print(f"  Target: {target}")
+
+    bar = _ProgressBar(0, f"{spec.name:14s}")
+
+    try:
+        with _open_with_redirects(spec.url) as response:
+            total = int(response.headers.get("Content-Length", "0"))
+            bar.total = total
+            sha = hashlib.sha256()
+            downloaded = 0
+            chunk = 1024 * 256  # 256 KB chunks → smooth UI without too much sys-call overhead
+
+            with tmp.open("wb") as fh:
+                while True:
+                    block = response.read(chunk)
+                    if not block:
+                        break
+                    fh.write(block)
+                    sha.update(block)
+                    downloaded += len(block)
+                    if on_progress is not None:
+                        on_progress(downloaded, total)
+                    else:
+                        bar.update(downloaded)
+        bar.finish()
+    except urllib.error.HTTPError as exc:
+        # Clean up partial file
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise DependencyError(
+            f"Download failed for model {name!r}: HTTP {exc.code} {exc.reason}\n"
+            f"  URL: {spec.url}\n"
+            f"  Try again, or check https://huggingface.co/ggerganov/whisper.cpp"
+        ) from exc
+    except urllib.error.URLError as exc:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise DependencyError(
+            f"Download failed for model {name!r}: {exc.reason}\n"
+            f"  URL: {spec.url}\n"
+            "  Check your network connection and try again."
+        ) from exc
+    except KeyboardInterrupt:
+        bar.finish()
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
+
+    # Sanity-check size (whisper.cpp doesn't publish per-file SHA-256 in a
+    # machine-readable way, so this is the strongest check we can make).
+    if total > 0 and downloaded != total:
+        tmp.unlink(missing_ok=True)
+        raise DependencyError(
+            f"Truncated download for {name!r}: got {downloaded} bytes, "
+            f"expected {total}. Try again."
+        )
+
+    # Atomic move into place
+    os.replace(tmp, target)
+    return target
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Removal
+# ──────────────────────────────────────────────────────────────────────
+
+
+def remove_model(name: str, whisper_dir: Path) -> Path:
+    """Delete a model file from disk.
+
+    Returns the path that was removed. Raises if the file isn't present.
+    """
+    target = model_path(whisper_dir, name)
+    if not target.is_file():
+        raise DependencyError(
+            f"Model {name!r} is not installed at {target}\n"
+            f"Run `localcaption model list` to see installed models."
+        )
+    target.unlink()
+    return target
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Listing helpers (consumed by the CLI for nice formatting)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ModelStatus:
+    """One row in the ``model list`` table."""
+
+    spec: ModelSpec
+    installed_at: Path | None   # None = not installed
+
+    @property
+    def is_installed(self) -> bool:
+        return self.installed_at is not None
+
+    @property
+    def actual_size_mb(self) -> int | None:
+        """Real on-disk size in MB, if installed."""
+        if self.installed_at is None:
+            return None
+        return max(1, self.installed_at.stat().st_size // (1024 * 1024))
+
+
+def list_status(whisper_dir: Path) -> list[ModelStatus]:
+    """Build the full status table: every known model + install state."""
+    installed = installed_model_files(whisper_dir)
+    return [
+        ModelStatus(spec=spec, installed_at=installed.get(spec.name))
+        for spec in known_models()
+    ]
+
+
+def orphaned_installed_models(whisper_dir: Path) -> list[str]:
+    """Models present on disk but not in our registry (e.g. user added a custom one)."""
+    known = {m.name for m in known_models()}
+    return sorted(name for name in installed_model_files(whisper_dir) if name not in known)

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -87,3 +87,100 @@ def test_unknown_subcommand_treated_as_url(monkeypatch) -> None:
     with pytest.raises(SystemExit):
         main(["https://example.com/video"])
     assert sentinel["url"] == "https://example.com/video"
+
+
+# --- doctor --fix --------------------------------------------------------
+
+
+def test_doctor_does_not_invoke_installer_without_fix(monkeypatch, tmp_path: Path) -> None:
+    """The diagnostic command must remain read-only by default.
+
+    Even when there are obvious gaps, plain ``doctor`` should never call into
+    the installer. This is the load-bearing safety guarantee.
+    """
+    def explode(*_a, **_kw):
+        raise AssertionError("installer must not be invoked without --fix")
+
+    monkeypatch.setattr("localcaption.installer.install_system_dep", explode)
+    monkeypatch.setattr("localcaption.installer.ensure_whisper_cpp", explode)
+    monkeypatch.setattr("localcaption.models.download_model", explode)
+
+    rc = main(["doctor", "--whisper-dir", str(tmp_path / "missing")])
+    assert rc == 1  # gaps detected, but no installs attempted
+
+
+def test_doctor_fix_invokes_installer_for_missing_whisper(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """`doctor --fix` should call ensure_whisper_cpp + download_model."""
+    whisper_dir = tmp_path / "whisper.cpp"
+    calls: dict[str, object] = {}
+
+    def fake_ensure(path):
+        calls["whisper_dir"] = path
+        # Simulate a successful build so the post-fix re-check passes.
+        bin_path = path / "build" / "bin" / "whisper-cli"
+        bin_path.parent.mkdir(parents=True, exist_ok=True)
+        bin_path.write_text("#!/bin/sh\nexit 0\n")
+        bin_path.chmod(0o755)
+        (path / "models").mkdir(exist_ok=True)
+        return bin_path
+
+    def fake_download(name, whisper_root, **_kw):
+        calls["model_name"] = name
+        calls["model_root"] = whisper_root
+        target = whisper_root / "models" / f"ggml-{name}.bin"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"\x00" * 32)
+        return target
+
+    def fake_install_dep(name):
+        calls.setdefault("deps_installed", []).append(name)  # type: ignore[union-attr]
+
+    monkeypatch.setattr("localcaption.installer.ensure_whisper_cpp", fake_ensure)
+    monkeypatch.setattr("localcaption.installer.install_system_dep", fake_install_dep)
+    monkeypatch.setattr("localcaption.models.download_model", fake_download)
+
+    rc = main(["doctor", "--fix", "--whisper-dir", str(whisper_dir),
+               "--model", "tiny.en"])
+
+    assert calls["whisper_dir"] == whisper_dir
+    assert calls["model_name"] == "tiny.en"
+    assert calls["model_root"] == whisper_dir
+    # rc depends on host env (yt-dlp/ffmpeg may still be missing in CI), so
+    # we only assert that the fix logic was driven, not the final exit code.
+    del rc
+
+
+def test_doctor_fix_aborts_when_install_step_fails(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    """A failing install step should print the error and exit non-zero."""
+    from localcaption.errors import InstallError
+
+    def fake_ensure(_path):
+        raise InstallError("simulated build failure")
+
+    monkeypatch.setattr("localcaption.installer.ensure_whisper_cpp", fake_ensure)
+    monkeypatch.setattr("localcaption.installer.install_system_dep",
+                        lambda _name: None)
+    # Should never get to model download if whisper.cpp setup fails.
+    monkeypatch.setattr(
+        "localcaption.models.download_model",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            AssertionError("download must not be reached")
+        ),
+    )
+
+    rc = main(["doctor", "--fix", "--whisper-dir", str(tmp_path / "missing")])
+    out = capsys.readouterr().out
+    assert "simulated build failure" in out
+    assert "Fix aborted" in out
+    assert rc == 1
+
+
+def test_doctor_help_advertises_fix_flag(capsys) -> None:
+    with pytest.raises(SystemExit):
+        main(["doctor", "--help"])
+    out = capsys.readouterr().out
+    assert "--fix" in out

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -1,0 +1,172 @@
+"""Tests for the `localcaption model {list,download,rm,info}` CLI plumbing.
+
+These tests exercise the dispatcher and exit codes — the actual download
+machinery is tested in test_models_download.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from localcaption import cli, models
+
+
+def _run(argv: list[str]) -> int:
+    """Run the CLI main() with no global side effects, return exit code."""
+    return cli.main(argv)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Dispatch
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_bare_model_prints_usage(capsys):
+    rc = _run(["model"])
+    out = capsys.readouterr().out
+    assert "subcommands" in out
+    assert "list" in out and "download" in out and "rm" in out
+    assert rc == 2  # bare invocation is an error per CLI conventions
+
+
+def test_model_help_exits_zero(capsys):
+    rc = _run(["model", "--help"])
+    out = capsys.readouterr().out
+    assert "subcommands" in out
+    assert rc == 0
+
+
+def test_unknown_subcommand_is_rejected(capsys):
+    rc = _run(["model", "frobnicate"])
+    err = capsys.readouterr().err
+    assert "unknown subcommand" in err
+    assert rc == 2
+
+
+# ──────────────────────────────────────────────────────────────────────
+# `model list`
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _make_whisper(tmp_path: Path, installed: list[str]) -> Path:
+    whisper = tmp_path / "whisper.cpp"
+    (whisper / "models").mkdir(parents=True)
+    for name in installed:
+        (whisper / "models" / f"ggml-{name}.bin").write_bytes(b"x")
+    return whisper
+
+
+def test_list_includes_all_known_models(tmp_path, capsys):
+    whisper = _make_whisper(tmp_path, [])
+    rc = _run(["model", "list", "--whisper-dir", str(whisper)])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    for spec in models.known_models():
+        assert spec.name in out
+    assert "not installed" in out
+
+
+def test_list_marks_installed_models(tmp_path, capsys):
+    whisper = _make_whisper(tmp_path, ["base.en"])
+    rc = _run(["model", "list", "--whisper-dir", str(whisper)])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    # The installed marker should appear at least once
+    assert "installed" in out
+    # base.en line must be on the same line as the installed marker
+    base_line = next(line for line in out.splitlines() if line.lstrip().startswith("base.en "))
+    assert "installed" in base_line
+
+
+def test_list_works_when_whisper_dir_missing(tmp_path, capsys):
+    """`model list` should never crash just because whisper.cpp isn't installed.
+
+    This is critical: a brand-new user runs `model list` to figure out what
+    to install BEFORE installing whisper.cpp.
+    """
+    nonexistent = tmp_path / "no-whisper-here"
+    rc = _run(["model", "list", "--whisper-dir", str(nonexistent)])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "base.en" in out
+    assert "not installed" in out
+
+
+def test_list_surfaces_orphan_models(tmp_path, capsys):
+    whisper = _make_whisper(tmp_path, ["base.en", "my-finetune"])
+    _run(["model", "list", "--whisper-dir", str(whisper)])
+    out = capsys.readouterr().out
+
+    assert "Other models found on disk" in out
+    assert "my-finetune" in out
+
+
+# ──────────────────────────────────────────────────────────────────────
+# `model info`
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_info_shows_metadata_for_known_model(tmp_path, capsys):
+    whisper = _make_whisper(tmp_path, [])
+    rc = _run(["model", "info", "small.en", "--whisper-dir", str(whisper)])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "small.en" in out
+    assert "English-only" in out
+    assert "huggingface.co" in out
+    assert "Installed:    no" in out
+
+
+def test_info_shows_installed_status_when_present(tmp_path, capsys):
+    whisper = _make_whisper(tmp_path, ["small.en"])
+    rc = _run(["model", "info", "small.en", "--whisper-dir", str(whisper)])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Installed:    yes" in out
+
+
+def test_info_unknown_model_returns_error(tmp_path, capsys):
+    rc = _run(["model", "info", "totally-fake"])
+    err = capsys.readouterr().err
+    assert "Unknown model" in err
+    assert rc == 2
+
+
+# ──────────────────────────────────────────────────────────────────────
+# `model rm`
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_rm_with_yes_flag_removes(tmp_path, capsys):
+    whisper = _make_whisper(tmp_path, ["base.en"])
+    target = whisper / "models" / "ggml-base.en.bin"
+    assert target.is_file()
+
+    rc = _run(["model", "rm", "base.en", "--whisper-dir", str(whisper), "-y"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert not target.exists()
+    assert "Removed" in out
+
+
+def test_rm_missing_model_returns_error(tmp_path, capsys):
+    whisper = _make_whisper(tmp_path, [])
+    rc = _run(["model", "rm", "base.en", "--whisper-dir", str(whisper), "-y"])
+    err = capsys.readouterr().err
+
+    assert rc == 1
+    assert "not installed" in err
+
+
+def test_rm_aliases(tmp_path):
+    """Both `rm`, `remove`, and `delete` should work — small affordance."""
+    for alias in ("rm", "remove", "delete"):
+        whisper = _make_whisper(tmp_path / alias, ["base.en"])
+        rc = _run(["model", alias, "base.en", "--whisper-dir", str(whisper), "-y"])
+        assert rc == 0, f"alias {alias!r} failed"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -17,7 +17,6 @@ import pytest
 from localcaption import installer
 from localcaption.errors import InstallError
 
-
 # --- Detection ------------------------------------------------------------
 
 

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,227 @@
+"""Tests for `localcaption.installer`.
+
+We can't actually `git clone` or `cmake --build` in unit tests, so every
+external command is mocked at the `subprocess.run` boundary. The goal is
+to exercise the *orchestration* logic — argument shape, ordering, skip
+conditions, error translation — not the underlying tools.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from localcaption import installer
+from localcaption.errors import InstallError
+
+
+# --- Detection ------------------------------------------------------------
+
+
+def test_detect_platform_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installer.platform, "system", lambda: "Darwin")
+    assert installer.detect_platform() == "macos"
+
+
+def test_detect_platform_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installer.platform, "system", lambda: "Linux")
+    assert installer.detect_platform() == "linux"
+
+
+def test_detect_platform_unsupported(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installer.platform, "system", lambda: "Windows")
+    assert installer.detect_platform() == "unsupported"
+
+
+def test_detect_package_manager_prefers_brew(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installer.shutil, "which",
+                        lambda name: "/opt/homebrew/bin/brew" if name == "brew" else None)
+    assert installer.detect_package_manager() == "brew"
+
+
+def test_detect_package_manager_falls_back_to_apt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installer.shutil, "which",
+                        lambda name: "/usr/bin/apt-get" if name == "apt-get" else None)
+    assert installer.detect_package_manager() == "apt"
+
+
+def test_detect_package_manager_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installer.shutil, "which", lambda _name: None)
+    assert installer.detect_package_manager() is None
+
+
+# --- _run wrapper ---------------------------------------------------------
+
+
+def test_run_raises_install_error_on_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd: list[str], **_kw: Any) -> None:
+        raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    with pytest.raises(InstallError, match="exit 1"):
+        installer._run(["false"], label="boom")
+
+
+def test_run_raises_install_error_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd: list[str], **_kw: Any) -> None:
+        raise FileNotFoundError(cmd[0])
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    with pytest.raises(InstallError, match="command not found"):
+        installer._run(["nope"], label="missing")
+
+
+def test_run_passes_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    seen: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kw: Any) -> None:
+        seen["cmd"] = cmd
+        seen["cwd"] = kw.get("cwd")
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    installer._run(["echo", "hi"], label="echo", cwd=tmp_path)
+    assert seen == {"cmd": ["echo", "hi"], "cwd": tmp_path}
+
+
+# --- install_system_dep ---------------------------------------------------
+
+
+def test_install_system_dep_skip_when_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installer.shutil, "which", lambda name: "/usr/bin/" + name)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(installer, "_run", lambda cmd, **_kw: calls.append(cmd))
+    installer.install_system_dep("ffmpeg")
+    assert calls == []  # nothing to do
+
+
+def test_install_system_dep_unknown_dep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installer.shutil, "which", lambda _name: None)
+    with pytest.raises(InstallError, match="Don't know how to install"):
+        installer.install_system_dep("nonsense-tool")
+
+
+def test_install_system_dep_no_package_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installer.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(installer.platform, "system", lambda: "Darwin")
+    with pytest.raises(InstallError, match="No supported package manager"):
+        installer.install_system_dep("ffmpeg")
+
+
+def test_install_system_dep_uses_brew_on_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    # ffmpeg missing, brew present.
+    def which(name: str) -> str | None:
+        return "/opt/homebrew/bin/brew" if name == "brew" else None
+
+    monkeypatch.setattr(installer.shutil, "which", which)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(installer, "_run", lambda cmd, **_kw: calls.append(cmd))
+    installer.install_system_dep("ffmpeg")
+    assert calls == [["brew", "install", "ffmpeg"]]
+
+
+def test_install_system_dep_uses_apt_on_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    def which(name: str) -> str | None:
+        return "/usr/bin/apt-get" if name == "apt-get" else None
+
+    monkeypatch.setattr(installer.shutil, "which", which)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(installer, "_run", lambda cmd, **_kw: calls.append(cmd))
+    installer.install_system_dep("cmake")
+    assert calls == [
+        ["sudo", "apt-get", "update", "-y"],
+        ["sudo", "apt-get", "install", "-y", "cmake"],
+    ]
+
+
+# --- ensure_whisper_cpp ---------------------------------------------------
+
+
+def _make_built_checkout(root: Path) -> Path:
+    """Lay out a fake whisper.cpp tree with an executable binary."""
+    binary = root / "build" / "bin" / "whisper-cli"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\nexit 0\n")
+    binary.chmod(0o755)
+    (root / "models").mkdir()
+    return binary
+
+
+def test_ensure_whisper_cpp_short_circuits_when_built(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    whisper_dir = tmp_path / "whisper.cpp"
+    whisper_dir.mkdir()
+    expected = _make_built_checkout(whisper_dir)
+
+    # No subprocess calls should happen.
+    def boom(*_a: Any, **_kw: Any) -> None:
+        raise AssertionError("subprocess.run should not be invoked")
+
+    monkeypatch.setattr(installer.subprocess, "run", boom)
+    binary = installer.ensure_whisper_cpp(whisper_dir)
+    assert binary == expected
+
+
+def test_ensure_whisper_cpp_clones_and_builds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    whisper_dir = tmp_path / "whisper.cpp"  # does not yet exist
+    calls: list[tuple[list[str], Path | None]] = []
+
+    def fake_run(cmd: list[str], *, label: str, cwd: Path | None = None) -> None:
+        calls.append((cmd, cwd))
+        # Simulate the side-effects of `git clone` and `cmake --build`.
+        if cmd[:2] == ["git", "clone"]:
+            whisper_dir.mkdir(parents=True)
+            (whisper_dir / "CMakeLists.txt").write_text("project(x)\n")
+        elif cmd[:2] == ["cmake", "--build"]:
+            _make_built_checkout(whisper_dir)
+
+    monkeypatch.setattr(installer, "_run", fake_run)
+    monkeypatch.setattr(installer.shutil, "which",
+                        lambda name: f"/usr/bin/{name}")  # git + cmake present
+
+    binary = installer.ensure_whisper_cpp(whisper_dir)
+
+    # Confirm sequencing: clone → cmake configure → cmake build.
+    assert [c[0][0] for c in calls] == ["git", "cmake", "cmake"]
+    assert calls[0][0][:2] == ["git", "clone"]
+    assert calls[1][0][:2] == ["cmake", "-B"]
+    assert calls[2][0][:2] == ["cmake", "--build"]
+    # cmake calls must run inside the checkout.
+    assert calls[1][1] == whisper_dir
+    assert calls[2][1] == whisper_dir
+    assert binary.is_file()
+
+
+def test_ensure_whisper_cpp_requires_git_when_cloning(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    whisper_dir = tmp_path / "whisper.cpp"  # missing
+    monkeypatch.setattr(installer.shutil, "which", lambda _name: None)
+    with pytest.raises(InstallError, match="git is required"):
+        installer.ensure_whisper_cpp(whisper_dir)
+
+
+def test_ensure_whisper_cpp_requires_cmake_when_building(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    whisper_dir = tmp_path / "whisper.cpp"
+    whisper_dir.mkdir()
+    (whisper_dir / "CMakeLists.txt").write_text("project(x)\n")
+    # No binary, no cmake → should fail with a hint.
+    monkeypatch.setattr(installer.shutil, "which", lambda _name: None)
+    with pytest.raises(InstallError, match="cmake is required"):
+        installer.ensure_whisper_cpp(whisper_dir)
+
+
+def test_ensure_whisper_cpp_rejects_non_directory(
+    tmp_path: Path,
+) -> None:
+    not_a_dir = tmp_path / "whisper.cpp"
+    not_a_dir.write_text("oops, this is a file")
+    with pytest.raises(InstallError, match="not a directory"):
+        installer.ensure_whisper_cpp(not_a_dir)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,128 @@
+"""Tests for ``localcaption.models`` — registry, listing, removal.
+
+Notes:
+- Network downloads are NOT exercised here (would be flaky and slow).
+  The download path is covered by an integration-style test that uses
+  a fake HTTP server in tests/test_models_download.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from localcaption import models
+from localcaption.errors import LocalCaptionError
+
+# ──────────────────────────────────────────────────────────────────────
+# Registry
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_registry_contains_well_known_models():
+    names = {m.name for m in models.known_models()}
+    # Sanity: any of these missing means we accidentally broke the registry.
+    for required in ("tiny.en", "base.en", "small.en", "large-v3"):
+        assert required in names, f"missing well-known model: {required}"
+
+
+def test_registry_is_sorted_smallest_first():
+    sizes = [m.approx_size_mb for m in models.known_models()]
+    assert sizes == sorted(sizes), "known_models() must be sorted by size ascending"
+
+
+def test_get_model_returns_spec():
+    spec = models.get_model("base.en")
+    assert spec.name == "base.en"
+    assert spec.is_english_only
+    assert spec.url.endswith("ggml-base.en.bin")
+    assert "huggingface.co" in spec.url
+
+
+def test_get_model_raises_on_unknown():
+    with pytest.raises(LocalCaptionError) as exc_info:
+        models.get_model("xxx-not-a-model")
+    msg = str(exc_info.value)
+    # Must give the user actionable info, not just "no".
+    assert "Unknown model" in msg
+    assert "model list" in msg
+
+
+def test_english_only_flag():
+    assert models.get_model("base.en").is_english_only
+    assert not models.get_model("base").is_english_only
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Disk introspection
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _make_fake_whisper_dir(root: Path, installed: list[str]) -> Path:
+    """Build a minimal whisper.cpp-shaped tree with the given fake models."""
+    whisper = root / "whisper.cpp"
+    (whisper / "models").mkdir(parents=True)
+    for name in installed:
+        # 1 byte per file is enough; tests don't care about real ggml format.
+        (whisper / "models" / f"ggml-{name}.bin").write_bytes(b"x")
+    return whisper
+
+
+def test_installed_model_files_empty_when_dir_missing(tmp_path):
+    # Should NOT raise — listing just returns an empty mapping.
+    assert models.installed_model_files(tmp_path / "no-such-dir") == {}
+
+
+def test_installed_model_files_finds_existing(tmp_path):
+    whisper = _make_fake_whisper_dir(tmp_path, ["base.en", "small.en"])
+    found = models.installed_model_files(whisper)
+    assert set(found.keys()) == {"base.en", "small.en"}
+    for path in found.values():
+        assert path.is_file()
+
+
+def test_list_status_marks_installed_correctly(tmp_path):
+    whisper = _make_fake_whisper_dir(tmp_path, ["base.en"])
+    rows = models.list_status(whisper)
+    by_name = {r.spec.name: r for r in rows}
+    assert by_name["base.en"].is_installed is True
+    assert by_name["small.en"].is_installed is False
+
+
+def test_orphaned_models_are_detected(tmp_path):
+    whisper = _make_fake_whisper_dir(tmp_path, ["base.en", "custom-finetune"])
+    orphans = models.orphaned_installed_models(whisper)
+    assert orphans == ["custom-finetune"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Removal
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_remove_model_deletes_file(tmp_path):
+    whisper = _make_fake_whisper_dir(tmp_path, ["base.en"])
+    target = whisper / "models" / "ggml-base.en.bin"
+    assert target.is_file()
+
+    removed = models.remove_model("base.en", whisper)
+    assert removed == target
+    assert not target.exists()
+
+
+def test_remove_model_raises_when_missing(tmp_path):
+    whisper = _make_fake_whisper_dir(tmp_path, [])  # nothing installed
+    with pytest.raises(LocalCaptionError) as exc_info:
+        models.remove_model("base.en", whisper)
+    assert "not installed" in str(exc_info.value)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Path helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_model_path_uses_whisper_dir_layout(tmp_path):
+    p = models.model_path(tmp_path, "small.en")
+    assert p == tmp_path / "models" / "ggml-small.en.bin"

--- a/tests/test_models_download.py
+++ b/tests/test_models_download.py
@@ -1,0 +1,160 @@
+"""Integration test for `models.download_model` against a local HTTP server.
+
+We don't want CI to hit the real Hugging Face servers (flaky, slow, and
+rude), but we DO want to exercise the actual urllib + progress + atomic-rename
+code path. So we spin up a tiny HTTPServer in a thread, monkeypatch the
+registry's HF_BASE_URL to point at it, and run the real downloader.
+"""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from localcaption import models
+from localcaption.errors import DependencyError
+
+# ──────────────────────────────────────────────────────────────────────
+# Tiny HTTP server fixture
+# ──────────────────────────────────────────────────────────────────────
+
+
+FAKE_PAYLOAD = b"fake-ggml-data-" * 1000  # ~15 KB; enough to test progress + I/O
+
+
+class _FakeWhisperHandler(BaseHTTPRequestHandler):
+    """Serves any /ggml-*.bin path with the same fake payload."""
+
+    truncate_after: int | None = None  # set per-test to simulate truncation
+    fail_with_status: int | None = None  # set per-test to simulate HTTP error
+
+    def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandler convention)
+        if self.fail_with_status is not None:
+            self.send_response(self.fail_with_status)
+            self.end_headers()
+            return
+
+        if not self.path.endswith(".bin"):
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        self.send_response(200)
+        body = FAKE_PAYLOAD
+        if self.truncate_after is not None:
+            # Lie about Content-Length to simulate a truncated download.
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body[: self.truncate_after])
+        else:
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    def log_message(self, *args, **kwargs):  # silence test noise
+        pass
+
+
+@pytest.fixture
+def fake_hf_server(monkeypatch):
+    """Spin up an HTTPServer that mimics huggingface.co for the duration of one test."""
+    # Reset class-level mutable defaults
+    _FakeWhisperHandler.truncate_after = None
+    _FakeWhisperHandler.fail_with_status = None
+
+    server = HTTPServer(("127.0.0.1", 0), _FakeWhisperHandler)
+    port = server.server_address[1]
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    # Redirect the registry's URL base to the fake server.
+    monkeypatch.setattr(models, "HF_BASE_URL", f"http://127.0.0.1:{port}")
+
+    yield _FakeWhisperHandler
+
+    server.shutdown()
+    server.server_close()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _empty_whisper_tree(root: Path) -> Path:
+    whisper = root / "whisper.cpp"
+    (whisper / "models").mkdir(parents=True)
+    return whisper
+
+
+def test_download_writes_file_atomically(tmp_path, fake_hf_server):
+    whisper = _empty_whisper_tree(tmp_path)
+
+    result = models.download_model("base.en", whisper)
+
+    assert result.is_file()
+    assert result.read_bytes() == FAKE_PAYLOAD
+    # Atomic-rename invariant: no .part file left lying around
+    assert not result.with_suffix(".bin.part").exists()
+
+
+def test_download_progress_callback_is_invoked(tmp_path, fake_hf_server):
+    whisper = _empty_whisper_tree(tmp_path)
+    calls: list[tuple[int, int]] = []
+
+    models.download_model(
+        "base.en", whisper, on_progress=lambda d, t: calls.append((d, t))
+    )
+
+    assert calls, "progress callback was never called"
+    final_downloaded, final_total = calls[-1]
+    assert final_downloaded == final_total == len(FAKE_PAYLOAD)
+
+
+def test_download_skips_when_already_present(tmp_path, fake_hf_server):
+    whisper = _empty_whisper_tree(tmp_path)
+    target = models.model_path(whisper, "base.en")
+    target.write_bytes(b"existing-content")
+
+    # Should be a no-op (no overwrite, no exception)
+    result = models.download_model("base.en", whisper)
+    assert result.read_bytes() == b"existing-content"
+
+
+def test_download_force_overwrites(tmp_path, fake_hf_server):
+    whisper = _empty_whisper_tree(tmp_path)
+    target = models.model_path(whisper, "base.en")
+    target.write_bytes(b"stale")
+
+    models.download_model("base.en", whisper, force=True)
+    assert target.read_bytes() == FAKE_PAYLOAD
+
+
+def test_download_truncated_response_raises(tmp_path, fake_hf_server):
+    _FakeWhisperHandler = fake_hf_server  # alias for clarity
+    _FakeWhisperHandler.truncate_after = 100  # send only 100 bytes despite 15 KB header
+
+    whisper = _empty_whisper_tree(tmp_path)
+    with pytest.raises(DependencyError) as exc_info:
+        models.download_model("base.en", whisper)
+    assert "Truncated" in str(exc_info.value)
+    # The .part file must have been cleaned up
+    assert not models.model_path(whisper, "base.en").exists()
+    assert not models.model_path(whisper, "base.en").with_suffix(".bin.part").exists()
+
+
+def test_download_http_error_is_friendly(tmp_path, fake_hf_server):
+    fake_hf_server.fail_with_status = 503
+
+    whisper = _empty_whisper_tree(tmp_path)
+    with pytest.raises(DependencyError) as exc_info:
+        models.download_model("base.en", whisper)
+    msg = str(exc_info.value)
+    assert "Download failed" in msg
+    assert "503" in msg
+    # No leftover artefacts on disk
+    assert not models.model_path(whisper, "base.en").exists()


### PR DESCRIPTION
## What & why

This PR turns `localcaption` into a **self-healing CLI**. Two themes, one cohesive UX:

### 1. First-class model management — `localcaption model …`

No more shelling into `download-ggml-model.sh`. New subcommands:

| Command | What it does |
|---|---|
| `localcaption model list` | Show every supported model with size + install status (works even before whisper.cpp is installed) |
| `localcaption model info <name>` | Show metadata for a single model |
| `localcaption model download <name>` | Native Python downloader: progress bar, atomic writes (`.part` → rename), Ctrl-C safety, truncation detection |
| `localcaption model rm <name>` | Remove an installed model (`-y` to skip confirm) |

Plus an **auto-download prompt on the transcribe path**: running `localcaption --model small.en <url>` when `small.en` isn't installed asks whether to download it instead of failing. Pass `--auto-download` for scripted use.

### 2. End-to-end self-healing — `localcaption doctor --fix`

`doctor` becomes the single command that turns a broken or missing install into a working one:

- Installs missing system tools (`ffmpeg` / `cmake` / `git`) via `brew` on macOS or `apt-get` on Linux.
- Clones + builds whisper.cpp at the canonical XDG location.
- Downloads the requested model (default `base.en`, override with `--model`).
- Re-runs the diagnostics for verification.
- **Idempotent** — safe to re-run; no-ops when already installed.

`doctor` is **read-only by default** — `--fix` is required to write anything. There's a regression test that monkeypatches the installer to explode if invoked without `--fix`, so this invariant is locked in.

### Bonus: `install.sh` consolidation

The bootstrap script slimmed from **134 → 91 lines**. It now only handles the chicken-and-egg parts (Python check, `pipx`, `pipx install localcaption`) and then delegates the heavy lifting to `localcaption doctor --fix`. **One source of truth** for "what does a working install look like."

## Implementation notes

- New module: `src/localcaption/installer.py` — pure-Python wrappers around `git`/`cmake`/`brew`/`apt`, no bash dependency. Streams subprocess output live so users see real progress on long-running steps.
- New module: `src/localcaption/models.py` — registry + atomic-write downloader, stdlib only (no `requests` dependency).
- New exception: `InstallError(LocalCaptionError)` for typed install-step failures.
- `_cmd_doctor` refactored into `_run_doctor_diagnostics` (read-only) + `_apply_doctor_fix` (write) for clean separation of concerns.

## Tests

- **68 tests, all green** (was 14 before this PR).
- `tests/test_models.py` — registry invariants, `get_model` errors, disk introspection, removal.
- `tests/test_models_download.py` — real `HTTPServer` in a thread (no Hugging Face hits) covering atomic writes, progress callbacks, skip-when-present, `force=`, truncation, HTTP errors.
- `tests/test_cli_model.py` — dispatch (bare/help/unknown), `list`/`info`/`rm` happy + error paths, `rm` aliases.
- `tests/test_installer.py` (new) — platform/package-manager detection, `_run` error translation, `install_system_dep` (skip/brew/apt/no-pm/unknown), `ensure_whisper_cpp` (short-circuit, full clone+build sequence, missing git, missing cmake, non-directory).
- `tests/test_cli_doctor.py` (extended) — read-only-by-default invariant, fix happy path, fix abort on failure, `--fix` advertised in `--help`.

## Manual smoke test

End-to-end run in a sandbox dir on an M-series Mac:

```
$ time localcaption doctor --whisper-dir $SANDBOX/whisper.cpp --fix --model tiny.en
…clone, cmake configure, cmake build (Metal + BLAS), download tiny.en…
All checks passed. You're good to go: localcaption <url>
real    0m35.933s
```

Re-running is idempotent (~1s, all-green diagnostic, no rebuild).

## Files changed at a glance

| File | Change |
|---|---|
| `src/localcaption/models.py` | NEW — registry + downloader |
| `src/localcaption/installer.py` | NEW — system-deps + whisper.cpp clone/build |
| `src/localcaption/cli.py` | `model` dispatcher, `doctor --fix`, auto-download prompt |
| `src/localcaption/errors.py` | + `InstallError` |
| `tests/test_models.py`, `test_models_download.py`, `test_cli_model.py`, `test_installer.py` | NEW |
| `tests/test_cli_doctor.py` | + `--fix` cases + read-only-by-default invariant |
| `scripts/install.sh` | Slimmed: delegate to `doctor --fix` |
| `README.md`, `CHANGELOG.md` | Document `model` family + `doctor --fix` |

## Closes / supersedes

- Supersedes the original goal of [#1] (changing the install default to `small.en`) — users now pick whichever model they want with one command, and `doctor --fix --model small.en` makes it a one-liner.
