### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-06
+
 ### Added
 - **`localcaption model` subcommand family** for first-class whisper model
   management. No more shelling into `download-ggml-model.sh`. Subcommands:


### PR DESCRIPTION
## Summary
- Finalize CHANGELOG for the v0.2.0 release: move `[Unreleased]` content under `[0.2.0] - 2026-06-06` and add a fresh empty `[Unreleased]` section.
- `pyproject.toml` version is already bumped to `0.2.0` — no version change needed.

## Highlights since v0.1.0
- **`localcaption model` subcommand family** — `list`, `info`, `download`, `rm` for first-class whisper model management
- **`localcaption doctor --fix`** — self-healing installer (system deps + whisper.cpp + model download)
- **Auto-download prompt** on the transcribe path when a model isn't installed
- **`scripts/uninstall.sh`** — idempotent end-to-end uninstaller
- **Improved `doctor` diagnostics** with actionable, copy-pasteable fix hints
- **README overhaul** — pipx as primary install path, broader site support docs, redesigned architecture diagrams
- **CI**: opted into Node 24 runtime for JavaScript actions

## After merge
1. Tag the merge commit on `main`: `git tag v0.2.0 && git push --tags`
2. The [Release workflow](.github/workflows/release.yml) will automatically build, publish to PyPI, and create the GitHub Release.