### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-16
+
+### Added
+- **Local video and audio files.** `localcaption /path/to/video.mp4` (or a
+  wav / mp3 / mkv / similar) runs the same ffmpeg + whisper.cpp path
+  without calling yt-dlp. Output names come from the input filename.
+
+### Changed
+- CLI help, `doctor`, and the README now say `<url-or-file>` instead of
+  treating this as URL-only.
+
+### Fixed
+- Architecture, pipeline, and sequence diagrams render with a white
+  background so they stay readable on GitHub dark mode.
+
 ## [0.2.0] - 2026-06-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "localcaption"
-version = "0.2.0"
+version = "0.3.0"
 description = "Fully-local video → transcript pipeline using yt-dlp, ffmpeg, and whisper.cpp. Supports YouTube, Vimeo, Twitch, and 1000+ sites. No API keys."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` from 0.2.0 to 0.3.0.
- Move the post-0.2.0 work under `[0.3.0] - 2026-08-16` and leave a fresh empty `[Unreleased]` section.

## Highlights since v0.2.0
- Local video and audio files: `localcaption /path/to/video.mp4` skips yt-dlp and runs the same ffmpeg + whisper.cpp path
- CLI help and README say `<url-or-file>`
- Diagrams render with a white background on GitHub dark mode

## After merge
1. Tag the merge commit on `main`: `git tag v0.3.0 && git push --tags`
2. The Release workflow will build, publish to PyPI, and create the GitHub Release.